### PR TITLE
#273: Added jupyterenv/bin to environment variable PATH inside the Entrypoint 

### DIFF
--- a/.github/actions/prepare_test_env/action.yml
+++ b/.github/actions/prepare_test_env/action.yml
@@ -25,7 +25,7 @@ runs:
      shell: bash
 
    - name: Setup Python & Poetry Environment
-     uses: exasol/python-toolbox/.github/actions/python-environment@0.13.0
+     uses: exasol/python-toolbox/.github/actions/python-environment@0.14.0
      with:
        python-version: "3.10"
        poetry-version: "1.8.2"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
        run: ./scripts/build/shellcheck.sh
 
      - name: Setup Python & Poetry Environment
-       uses: exasol/python-toolbox/.github/actions/python-environment@0.13.0
+       uses: exasol/python-toolbox/.github/actions/python-environment@0.14.0
        with:
          python-version: "3.10"
          poetry-version: "1.8.2"

--- a/.github/workflows/hyperlinks.yaml
+++ b/.github/workflows/hyperlinks.yaml
@@ -14,7 +14,7 @@ jobs:
          fetch-depth: 0
 
      - name: Setup Python & Poetry Environment
-       uses: exasol/python-toolbox/.github/actions/python-environment@0.13.0
+       uses: exasol/python-toolbox/.github/actions/python-environment@0.14.0
        with:
          python-version: "3.10"
          poetry-version: '1.8.2'

--- a/.github/workflows/release_droid_upload_github_release_assets.yml
+++ b/.github/workflows/release_droid_upload_github_release_assets.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Python & Poetry Environment
-        uses: exasol/python-toolbox/.github/actions/python-environment@0.13.0
+        uses: exasol/python-toolbox/.github/actions/python-environment@0.14.0
         with:
           python-version: "3.10"
           poetry-version: '1.8.2'
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup Python & Poetry Environment
-        uses: exasol/python-toolbox/.github/actions/python-environment@0.13.0
+        uses: exasol/python-toolbox/.github/actions/python-environment@0.14.0
         with:
           python-version: "3.10"
           poetry-version: '1.8.2'

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Setup Python & Poetry Environment
-      uses: exasol/python-toolbox/.github/actions/python-environment@0.13.0
+      uses: exasol/python-toolbox/.github/actions/python-environment@0.14.0
       with:
         python-version: "3.10"
         poetry-version: '1.8.2'

--- a/doc/changes/changes_2.1.0.md
+++ b/doc/changes/changes_2.1.0.md
@@ -18,7 +18,7 @@ Version: 2.1.0
 * #279: Made the notebooks tests running in SaaS as well as in the Docker-DB.
 * #19: Added SLC notebook
 * #301: Added CloudFront distribution for example data S3 bucket
-* #273: Added `jupyterenv/bin` to evironment variable `PATH` inside the DockerContainer
+* #273: Added `jupyterenv/bin` to environment variable `PATH` inside the DockerContainer
 
 ## Security
 
@@ -42,4 +42,4 @@ Version: 2.1.0
 * #193: Ignored warnings in notebook tests
 * #297: Reduced log level for transitive libraries in notebook tests
 * #307: Made the notebook tests running in parallel;
-        moved common steps from test jobs to a composite action 
+        moved common steps from test jobs to a composite action

--- a/doc/changes/changes_2.1.0.md
+++ b/doc/changes/changes_2.1.0.md
@@ -18,6 +18,7 @@ Version: 2.1.0
 * #279: Made the notebooks tests running in SaaS as well as in the Docker-DB.
 * #19: Added SLC notebook
 * #301: Added CloudFront distribution for example data S3 bucket
+* #273: Added `jupyterenv/bin` to evironment variable `PATH` inside the DockerContainer
 
 ## Security
 

--- a/doc/changes/changes_2.1.0.md
+++ b/doc/changes/changes_2.1.0.md
@@ -18,7 +18,7 @@ Version: 2.1.0
 * #279: Made the notebooks tests running in SaaS as well as in the Docker-DB.
 * #19: Added SLC notebook
 * #301: Added CloudFront distribution for example data S3 bucket
-* #273: Added `jupyterenv/bin` to environment variable `PATH` inside the DockerContainer
+* #273: Added `jupyterenv/bin` to environment variable `PATH` for running Jupyter Server
 
 ## Security
 

--- a/doc/user_guide/docker/prerequisites.md
+++ b/doc/user_guide/docker/prerequisites.md
@@ -39,7 +39,7 @@ This is only possible when using
 * MacOSX Docker Desktop
 * MacOSX Docker Desktop with a remote Docker daemon
 
-In all scenarios the daemon machine must allow running the Exasol Docker-DB with option [`--privileged`](https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities).
+In all scenarios the daemon machine must allow running the Exasol Docker-DB with option [`--privileged`](https://docs.docker.com/engine/containers/run/#runtime-privilege-and-linux-capabilities).
 
 Please note that enabling Exasol AI-Lab to use Docker features creates security risks. In particular, code running inside the AI-Lab could create privileged containers, mount the file system of the machine running the Docker daemon, and gain root access to it. For details see https://jpetazzo.github.io/2015/09/03/do-not-use-docker-in-docker-for-ci/, section "The socket solution".
 

--- a/exasol/ds/sandbox/lib/dss_docker/create_image.py
+++ b/exasol/ds/sandbox/lib/dss_docker/create_image.py
@@ -175,7 +175,8 @@ class DssDockerImage:
             "Env": [
                 f"VIRTUAL_ENV={virtualenv}",
                 f"NOTEBOOK_FOLDER_FINAL={notebook_folder_final}",
-                f"NOTEBOOK_FOLDER_INITIAL={notebook_folder_initial}"
+                f"NOTEBOOK_FOLDER_INITIAL={notebook_folder_initial}",
+                f'PATH="$PATH:{virtualenv}/bin"',
             ],
         }
         img = container.commit(repository=self.image_name, conf=conf)

--- a/exasol/ds/sandbox/lib/dss_docker/create_image.py
+++ b/exasol/ds/sandbox/lib/dss_docker/create_image.py
@@ -158,7 +158,7 @@ class DssDockerImage:
     def _path(self, container: DockerContainer, dir: str) -> str:
         for v in container.attrs["Config"]["Env"]:
             if v.startswith("PATH="):
-                return f"{v[5:]}:{dir}"
+                return f"{dir}:{v[5:]}"
         return dir
 
     def _commit_container(

--- a/exasol/ds/sandbox/lib/dss_docker/create_image.py
+++ b/exasol/ds/sandbox/lib/dss_docker/create_image.py
@@ -156,10 +156,10 @@ class DssDockerImage:
         )
 
     def _path(self, container: DockerContainer, dir: str) -> str:
-        env_list = container.attrs["Config"]["Env"]
-        env_dict = dict(e.split("=", 1) for e in env_list)
-        path = env_dict.get("PATH")
-        return f"{path}:{dir}" if path else dir
+        for v in container.attrs["Config"]["Env"]:
+            if v.startswith("PATH="):
+                return f"{v[5:]}:{dir}"
+        return dir
 
     def _commit_container(
             self,

--- a/exasol/ds/sandbox/lib/dss_docker/create_image.py
+++ b/exasol/ds/sandbox/lib/dss_docker/create_image.py
@@ -176,7 +176,7 @@ class DssDockerImage:
                 f"VIRTUAL_ENV={virtualenv}",
                 f"NOTEBOOK_FOLDER_FINAL={notebook_folder_final}",
                 f"NOTEBOOK_FOLDER_INITIAL={notebook_folder_initial}",
-                f'PATH="$PATH:{virtualenv}/bin"',
+                f"PATH=$PATH:{virtualenv}/bin",
             ],
         }
         img = container.commit(repository=self.image_name, conf=conf)

--- a/exasol/ds/sandbox/lib/dss_docker/create_image.py
+++ b/exasol/ds/sandbox/lib/dss_docker/create_image.py
@@ -155,12 +155,6 @@ class DssDockerImage:
             ansible_repositories=ansible_repository.default_repositories,
         )
 
-    def _path(self, container: DockerContainer, dir: str) -> str:
-        for v in container.attrs["Config"]["Env"]:
-            if v.startswith("PATH="):
-                return f"{dir}:{v[5:]}"
-        return dir
-
     def _commit_container(
             self,
             container: DockerContainer,
@@ -173,7 +167,6 @@ class DssDockerImage:
         notebook_folder_final = get_fact(facts, "notebook_folder", "final")
         notebook_folder_initial = get_fact(facts, "notebook_folder", "initial")
 
-        path = self._path(container, f"{virtualenv}/bin")
         conf = {
             "Entrypoint": entrypoint(facts),
             "Cmd": [],
@@ -184,7 +177,6 @@ class DssDockerImage:
                 f"VIRTUAL_ENV={virtualenv}",
                 f"NOTEBOOK_FOLDER_FINAL={notebook_folder_final}",
                 f"NOTEBOOK_FOLDER_INITIAL={notebook_folder_initial}",
-                f"PATH={path}",
             ],
         }
         img = container.commit(repository=self.image_name, conf=conf)

--- a/exasol/ds/sandbox/lib/dss_docker/create_image.py
+++ b/exasol/ds/sandbox/lib/dss_docker/create_image.py
@@ -48,7 +48,6 @@ def entrypoint(facts: AnsibleFacts) -> List[str]:
         password = get_fact(facts, "jupyter", "password")
         logfile = get_fact(facts, "jupyter", "logfile")
         virtualenv = get_fact(facts, "jupyter", "virtualenv")
-        venv_activate = f"{virtualenv}/bin/activate"
         return [
             "--home", user_home,
             "--jupyter-server", command,
@@ -58,7 +57,7 @@ def entrypoint(facts: AnsibleFacts) -> List[str]:
             "--docker-group", docker_group,
             "--password", password,
             "--jupyter-logfile", logfile,
-            "--venv", venv_activate,
+            "--venv", virtualenv,
         ]
 
     entrypoint = get_fact(facts, "entrypoint")

--- a/exasol/ds/sandbox/runtime/ansible/roles/entrypoint/files/entrypoint.py
+++ b/exasol/ds/sandbox/runtime/ansible/roles/entrypoint/files/entrypoint.py
@@ -107,6 +107,8 @@ def start_jupyter_server(
 
     env = os.environ.copy()
     env["HOME"] = home_directory
+    # path = env.get("PATH")
+    # enf["PATH"] = f"{dir}:{path}" if path else dir
     with open(logfile, "w") as f:
         p = subprocess.Popen(command_line, stdout=f, stderr=f, env=env)
 

--- a/exasol/ds/sandbox/runtime/ansible/roles/entrypoint/files/entrypoint.py
+++ b/exasol/ds/sandbox/runtime/ansible/roles/entrypoint/files/entrypoint.py
@@ -37,8 +37,8 @@ def arg_parser():
         help="destination location for notebook files to copy",
     )
     parser.add_argument(
-        "--venv", type=Path, metavar="<PATH-TO-ACTIVATE-SCRIPT>",
-        help="Source this script to activate a virtual environment before starting Jupyter server",
+        "--venv", type=Path, metavar="<PATH-TO-VIRTUAL-ENVIRONMENT>",
+        help="Prepend subdirectory bin to environment variable PATH before starting Jupyter server",
     )
     parser.add_argument(
         "--jupyter-server", metavar="<PATH-TO-JUPYTER-BINARY>",
@@ -117,15 +117,11 @@ def start_jupyter_server(
 
     env = os.environ.copy()
     env["HOME"] = home_directory
-    # path = env.get("PATH")
-    # enf["PATH"] = f"{dir}:{path}" if path else dir
-#     if venv:
-#         command_line = command_with_venv(venv, command_line)
-#         # command_line = command_with_venv(venv, ["echo", "$PS1"])
-#     # else:
-#     #     command_line = ["bash", "-c", "echo", "$PS1"]
-# 
-#     print(f'{command_line}')
+    if venv:
+        venv_bin = str(venv / "bin")
+        path = env.get("PATH")
+        env["PATH"] = f"{venv_bin}:{path}" if path else venv_bin
+        _logger.info(f'Changed environment variable PATH to {env["PATH"]}')
     with open(logfile, "w") as f:
         p = subprocess.Popen(command_line, stdout=f, stderr=f, env=env)
 
@@ -355,11 +351,11 @@ def main():
             f" {args.notebook_defaults} to {args.notebooks}")
     disable_core_dumps()
     if (args.jupyter_server
-        # and args.notebooks
-        # and args.jupyter_logfile
-        # and args.user
-        # and args.home
-        # and args.password
+        and args.notebooks
+        and args.jupyter_logfile
+        and args.user
+        and args.home
+        and args.password
         ):
         start_jupyter_server(
             args.home,

--- a/exasol/ds/sandbox/runtime/ansible/roles/entrypoint/files/entrypoint.py
+++ b/exasol/ds/sandbox/runtime/ansible/roles/entrypoint/files/entrypoint.py
@@ -79,11 +79,6 @@ def arg_parser():
     return parser
 
 
-def command_with_venv(venv_activate: Path, command: List[str]) -> List[str]:
-    bash_cmd = [ "source", str(venv_activate), ";" ] + command
-    return [ "bash", "-c", " ".join(bash_cmd) ]
-
-
 def start_jupyter_server(
         home_directory: str,
         binary_path: str,

--- a/test/unit/entrypoint/test_main.py
+++ b/test/unit/entrypoint/test_main.py
@@ -83,7 +83,7 @@ def test_jupyter(mocker):
     port = "1234"
     notebook_folder = Path("/root/notebooks")
     logfile = Path("/root/jupyter-server.log")
-    venv = Path("/root/jupyterenv/bin/activate")
+    venv = Path("/root/jupyterenv")
     mocker.patch("sys.argv", [
         "app",
         "--home", "home-directory",

--- a/test/unit/entrypoint/test_start_jupyter_server.py
+++ b/test/unit/entrypoint/test_start_jupyter_server.py
@@ -40,7 +40,7 @@ class Testee:
             self.logfile,
             "user",
             "password",
-            None,
+            Path("venv"),
             poll_sleep = 0.1,
         )
         return self
@@ -63,5 +63,6 @@ def test_late_error(tmp_path, caplog):
     with pytest.raises(SystemExit) as ex:
         testee = Testee(tmp_path).create_script(after="exit 23").run()
     assert ex.value.code == 23
+    assert "Changed environment variable PATH to venv/bin:" in caplog.text
     assert "Server for Jupyter has been started successfully." in caplog.text
     assert "Jupyter Server terminated with error code 23" in caplog.text

--- a/test/unit/test_dss_docker_image.py
+++ b/test/unit/test_dss_docker_image.py
@@ -144,7 +144,7 @@ def test_push_called(mocker, mocked_docker_image):
 @pytest.mark.parametrize(
     "env, expected", (
         ( ["A=1"], "jupyterenv/bin"),
-        ( ["A=1", "PATH=a:b:c"], "a:b:c:jupyterenv/bin"),
+        ( ["A=1", "PATH=a:b:c"], "jupyterenv/bin:a:b:c"),
     )
 )
 def test_path(sample_repo, env, expected):

--- a/test/unit/test_dss_docker_image.py
+++ b/test/unit/test_dss_docker_image.py
@@ -141,13 +141,13 @@ def test_push_called(mocker, mocked_docker_image):
     assert testee.registry.push.call_args_list == expected
 
 
-@pytest.mark.parametrize(
-    "env, expected", (
-        ( ["A=1"], "jupyterenv/bin"),
-        ( ["A=1", "PATH=a:b:c"], "jupyterenv/bin:a:b:c"),
-    )
-)
-def test_path(sample_repo, env, expected):
-    testee = DssDockerImage(sample_repo)
-    container = Mock(attrs={"Config": {"Env": env}})
-    assert expected == testee._path(container, "jupyterenv/bin")
+# @pytest.mark.parametrize(
+#     "env, expected", (
+#         ( ["A=1"], "jupyterenv/bin"),
+#         ( ["A=1", "PATH=a:b:c"], "jupyterenv/bin:a:b:c"),
+#     )
+# )
+# def test_path(sample_repo, env, expected):
+#     testee = DssDockerImage(sample_repo)
+#     container = Mock(attrs={"Config": {"Env": env}})
+#     assert expected == testee._path(container, "jupyterenv/bin")

--- a/test/unit/test_dss_docker_image.py
+++ b/test/unit/test_dss_docker_image.py
@@ -79,6 +79,7 @@ def test_entrypoint_with_copy_args():
         "dss_facts": {
             "docker_group": "docker-group-name",
             "jupyter": {
+                "virtualenv": "/home/jupyter/jupyterenv",
                 "command": "/home/jupyter/jupyterenv/bin/jupyter-lab",
                 "port": "port",
                 "user": "jupyter-user-name",
@@ -101,6 +102,7 @@ def test_entrypoint_with_copy_args():
         "--notebook-defaults": fact("notebook_folder", "initial"),
         "--notebooks": fact("notebook_folder", "final"),
         "--home": fact("jupyter", "home"),
+        "--venv": fact("jupyter", "virtualenv"),
         "--jupyter-server": fact("jupyter", "command"),
         "--port": fact("jupyter", "port"),
         "--user": fact("jupyter", "user"),
@@ -139,15 +141,3 @@ def test_push_called(mocker, mocked_docker_image):
         mocker.call(testee.repository, "latest"),
     ]
     assert testee.registry.push.call_args_list == expected
-
-
-# @pytest.mark.parametrize(
-#     "env, expected", (
-#         ( ["A=1"], "jupyterenv/bin"),
-#         ( ["A=1", "PATH=a:b:c"], "jupyterenv/bin:a:b:c"),
-#     )
-# )
-# def test_path(sample_repo, env, expected):
-#     testee = DssDockerImage(sample_repo)
-#     container = Mock(attrs={"Config": {"Env": env}})
-#     assert expected == testee._path(container, "jupyterenv/bin")

--- a/test/unit/test_dss_docker_image.py
+++ b/test/unit/test_dss_docker_image.py
@@ -139,3 +139,15 @@ def test_push_called(mocker, mocked_docker_image):
         mocker.call(testee.repository, "latest"),
     ]
     assert testee.registry.push.call_args_list == expected
+
+
+@pytest.mark.parametrize(
+    "env, expected", (
+        ( ["A=1"], "jupyterenv/bin"),
+        ( ["A=1", "PATH=a:b:c"], "a:b:c:jupyterenv/bin"),
+    )
+)
+def test_path(sample_repo, env, expected):
+    testee = DssDockerImage(sample_repo)
+    container = Mock(attrs={"Config": {"Env": env}})
+    assert expected == testee._path(container, "jupyterenv/bin")


### PR DESCRIPTION
Closes #273 

* At least the Docker Edition of the AI-Lab, already contains a system-wide installation of `pip` in `/usr/bin/pip` 
* Hence, directory  `/home/jupyter/jupyterenv/bin` needs to be _prepended_ to environment variable `PATH` in order to override the system-wide binary 
* `python -m pip would also be fine` since `python` and `pip` both are aware of the directory of the initially called binary

Actually, inside a Jupyter notebook the Jupyter virtual env should be activated anyway, but we have observations not confirming this assumption.
