### PR TITLE
Optimize notebook CI by batching SaaS tests and selective image builds

### DIFF
--- a/.github/actions/prepare_test_env/action.yml
+++ b/.github/actions/prepare_test_env/action.yml
@@ -1,16 +1,23 @@
 name: 'Prepare Test Environment'
 description: 'A custom action performing common steps required for running tests'
+inputs:
+  free-disk-space:
+    description: 'Whether to run disk cleanup before setting up test tooling'
+    required: false
+    default: 'true'
 
 runs:
   using: 'composite'
   steps:
    - name: Free disk space with jlumbroso
+     if: ${{ inputs.free-disk-space == 'true' }}
      uses: jlumbroso/free-disk-space@main
      with:
        tool-cache: true
        large-packages: false
 
    - name: Free disk space by removing large directories
+     if: ${{ inputs.free-disk-space == 'true' }}
      run: |
        sudo rm -rf /usr/local/graalvm/
        sudo rm -rf /usr/local/.ghcup/
@@ -21,6 +28,7 @@ runs:
      shell: bash
 
    - name: Show available disk space
+     if: ${{ inputs.free-disk-space == 'true' }}
      shell: bash
      run: df -h
 

--- a/.github/workflows/notebook_docker_image_builder.yaml
+++ b/.github/workflows/notebook_docker_image_builder.yaml
@@ -3,12 +3,44 @@ name: Notebook Docker Image Builder
 on:
   workflow_call:
 jobs:
+  get-required-wip-image-matrix:
+    runs-on: ubuntu-24.04
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - id: set-matrix
+        shell: bash
+        run: |
+          MATRIX_JSON=$(python - <<'PY'
+          import json
+          import re
+          from pathlib import Path
+
+          content = Path("nb_tests.yaml").read_text(encoding="utf-8")
+          wips = []
+          for line in content.splitlines():
+              match = re.match(r"^\s*wip:\s*(\S+)\s*$", line)
+              if match:
+                  value = match.group(1)
+                  if value not in wips:
+                      wips.append(value)
+          if not wips:
+              wips = ["no-wip"]
+          print(json.dumps({"wip": wips}))
+          PY
+          )
+          echo "matrix=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
+
   notebook-tests-docker-image-builder:
+    needs: [get-required-wip-image-matrix]
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: true
-      matrix:
-        wip: [no-wip, wip]
+      matrix: ${{ fromJson(needs.get-required-wip-image-matrix.outputs.matrix) }}
     name: Running Build Docker image - ${{ matrix.wip }}
     env:
       DOCKER_TAG: "${{ matrix.wip }}-${{ github.sha }}"

--- a/.github/workflows/notebook_tests.yaml
+++ b/.github/workflows/notebook_tests.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - id: set-tests
         run: |
-          TESTS=`poetry run -- nox -s get-notebook-tests-ci -- --test-status ${{ inputs.status-filter }} --test-classification ${{ inputs.test-classification }}`
+          TESTS=`poetry run -- nox -s get-notebook-tests -- --test-status ${{ inputs.status-filter }} --test-classification ${{ inputs.test-classification }}`
           echo "tests=$TESTS" >> "$GITHUB_OUTPUT"
 
       - id: set-runner
@@ -65,6 +65,8 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/prepare_test_env/
+        with:
+          free-disk-space: "false"
 
       - name: Download AI Lab image ${{matrix.nb_test.wip}}
         id: download-image

--- a/.github/workflows/notebook_tests.yaml
+++ b/.github/workflows/notebook_tests.yaml
@@ -27,7 +27,7 @@ jobs:
 
       - id: set-tests
         run: |
-          TESTS=`poetry run -- nox -s get-notebook-tests -- --test-status ${{ inputs.status-filter }} --test-classification ${{ inputs.test-classification }}`
+          TESTS=`poetry run -- nox -s get-notebook-tests-ci -- --test-status ${{ inputs.status-filter }} --test-classification ${{ inputs.test-classification }}`
           echo "tests=$TESTS" >> "$GITHUB_OUTPUT"
 
       - id: set-runner
@@ -83,8 +83,8 @@ jobs:
             --override-ini=log_cli=true \
             --override-ini=log_cli_level=INFO \
             --dss-docker-image="exasol/ai-lab:$DOCKER_TAG" \
-            --nb-test-backend=${{ matrix.nb_test.test_backend }} \
-            --nb-test-file=${{ matrix.nb_test.test_file }} \
+            --nb-test-backend="${{ matrix.nb_test.test_backend }}" \
+            --nb-test-file="${{ matrix.nb_test.test_file }}" \
             ${{ needs.fetch-notebook-tests.outputs.additional-pytest-parameters }} \
             test/notebook_test_runner/test_notebooks_in_dss_docker_image.py
 

--- a/nb_tests.yaml
+++ b/nb_tests.yaml
@@ -45,7 +45,7 @@ normal:
         test_backend: onprem
         wip: no-wip
       - name: short notebook tests
-        test_file: "\"nbtest_environment_test.py nbtest_itde.py\""
+        test_file: "nbtest_environment_test.py nbtest_itde.py"
         test_backend: ''
         wip: no-wip
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,5 @@
 import json
+import shlex
 from argparse import ArgumentParser, Namespace
 from enum import Enum
 from pathlib import Path
@@ -102,6 +103,53 @@ def _get_tests_for_classification(test_classification: TestClassification) -> Te
     }
     return mapping[test_classification]
 
+
+def _split_notebook_test_files(raw_test_file_value: str) -> List[str]:
+    return [
+        test_file
+        for token in shlex.split(raw_test_file_value)
+        for test_file in token.split()
+        if test_file
+    ]
+
+
+def _merge_test_batch(batch: List[NBTestDescription]) -> NBTestDescription:
+    base = batch[0]
+    test_files: List[str] = []
+    for test in batch:
+        test_files.extend(_split_notebook_test_files(test.test_file))
+    return NBTestDescription(
+        name=f"SaaS notebook batch ({len(batch)} tests)",
+        test_file=" ".join(test_files),
+        test_backend=base.test_backend,
+        wip=base.wip,
+    )
+
+
+def _batch_saas_tests_for_ci(tests: TestList) -> TestList:
+    batches: List[List[NBTestDescription]] = []
+    saas_batch_index_by_wip: dict[WipStatus, int] = {}
+
+    for test in tests.tests:
+        if test.test_backend != NBTestBackend.saas:
+            batches.append([test])
+            continue
+
+        batch_index = saas_batch_index_by_wip.get(test.wip)
+        if batch_index is None:
+            batch_index = len(batches)
+            batches.append([])
+            saas_batch_index_by_wip[test.wip] = batch_index
+        batches[batch_index].append(test)
+
+    optimized_tests: List[NBTestDescription] = []
+    for batch in batches:
+        if len(batch) == 1:
+            optimized_tests.append(batch[0])
+        else:
+            optimized_tests.append(_merge_test_batch(batch))
+    return TestList(tests=optimized_tests)
+
 @nox.session(name="get-notebook-tests", python=False)
 def get_notebook_tests(session: nox.Session):
     """
@@ -111,6 +159,17 @@ def get_notebook_tests(session: nox.Session):
     nb_tests = _get_tests_for_classification(args.test_classification)
     tests = nb_tests.stable if args.test_status == TestStatus.stable else nb_tests.unstable
     print(tests.model_dump_json())
+
+
+@nox.session(name="get-notebook-tests-ci", python=False)
+def get_notebook_tests_ci(session: nox.Session):
+    """
+    Same as get-notebook-tests, but groups SaaS tests into batches to reduce CI setup overhead.
+    """
+    args = _parse_args(session)
+    nb_tests = _get_tests_for_classification(args.test_classification)
+    tests = nb_tests.stable if args.test_status == TestStatus.stable else nb_tests.unstable
+    print(_batch_saas_tests_for_ci(tests).model_dump_json())
 
 
 @nox.session(name="get-runner", python=False)

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,4 @@
 import json
-import shlex
 from argparse import ArgumentParser, Namespace
 from enum import Enum
 from pathlib import Path
@@ -103,53 +102,6 @@ def _get_tests_for_classification(test_classification: TestClassification) -> Te
     }
     return mapping[test_classification]
 
-
-def _split_notebook_test_files(raw_test_file_value: str) -> List[str]:
-    return [
-        test_file
-        for token in shlex.split(raw_test_file_value)
-        for test_file in token.split()
-        if test_file
-    ]
-
-
-def _merge_test_batch(batch: List[NBTestDescription]) -> NBTestDescription:
-    base = batch[0]
-    test_files: List[str] = []
-    for test in batch:
-        test_files.extend(_split_notebook_test_files(test.test_file))
-    return NBTestDescription(
-        name=f"SaaS notebook batch ({len(batch)} tests)",
-        test_file=" ".join(test_files),
-        test_backend=base.test_backend,
-        wip=base.wip,
-    )
-
-
-def _batch_saas_tests_for_ci(tests: TestList) -> TestList:
-    batches: List[List[NBTestDescription]] = []
-    saas_batch_index_by_wip: dict[WipStatus, int] = {}
-
-    for test in tests.tests:
-        if test.test_backend != NBTestBackend.saas:
-            batches.append([test])
-            continue
-
-        batch_index = saas_batch_index_by_wip.get(test.wip)
-        if batch_index is None:
-            batch_index = len(batches)
-            batches.append([])
-            saas_batch_index_by_wip[test.wip] = batch_index
-        batches[batch_index].append(test)
-
-    optimized_tests: List[NBTestDescription] = []
-    for batch in batches:
-        if len(batch) == 1:
-            optimized_tests.append(batch[0])
-        else:
-            optimized_tests.append(_merge_test_batch(batch))
-    return TestList(tests=optimized_tests)
-
 @nox.session(name="get-notebook-tests", python=False)
 def get_notebook_tests(session: nox.Session):
     """
@@ -159,17 +111,6 @@ def get_notebook_tests(session: nox.Session):
     nb_tests = _get_tests_for_classification(args.test_classification)
     tests = nb_tests.stable if args.test_status == TestStatus.stable else nb_tests.unstable
     print(tests.model_dump_json())
-
-
-@nox.session(name="get-notebook-tests-ci", python=False)
-def get_notebook_tests_ci(session: nox.Session):
-    """
-    Same as get-notebook-tests, but groups SaaS tests into batches to reduce CI setup overhead.
-    """
-    args = _parse_args(session)
-    nb_tests = _get_tests_for_classification(args.test_classification)
-    tests = nb_tests.stable if args.test_status == TestStatus.stable else nb_tests.unstable
-    print(_batch_saas_tests_for_ci(tests).model_dump_json())
 
 
 @nox.session(name="get-runner", python=False)


### PR DESCRIPTION
Summary:
- Keep notebook tests separate (no SaaS test batching) to preserve the previous per-test job behavior.
- Build only required notebook docker image variants based on wip values in nb_tests.yaml, instead of always building both variants.
- Add a lightweight mode to the prepare_test_env composite action and use it for notebook runner jobs to skip expensive disk-cleanup steps there.
- Keep safer quoting for --nb-test-file and --nb-test-backend arguments.
- Normalize the multi-file notebook test entry format in nb_tests.yaml.

Expected impact:
- Preserves existing test granularity and reporting.
- Reduces CI startup overhead per notebook test job.
- Avoids unnecessary docker image builds when only one image variant is referenced.